### PR TITLE
Add parameter to always use 4-byte start codes before NAL units

### DIFF
--- a/encoder/encoder.c
+++ b/encoder/encoder.c
@@ -2004,7 +2004,8 @@ static int encoder_encapsulate_nals( x264_t *h, int start )
 
     for( int i = start; i < h->out.i_nal; i++ )
     {
-        h->out.nal[i].b_long_startcode = !i || h->out.nal[i].i_type == NAL_SPS || h->out.nal[i].i_type == NAL_PPS ||
+        h->out.nal[i].b_long_startcode = !i || h->param.b_long_startcode ||
+                                         h->out.nal[i].i_type == NAL_SPS || h->out.nal[i].i_type == NAL_PPS ||
                                          h->param.i_avcintra_class;
         x264_nal_encode( h, nal_buffer, &h->out.nal[i] );
         nal_buffer += h->out.nal[i].i_payload;

--- a/x264.h
+++ b/x264.h
@@ -491,8 +491,9 @@ typedef struct x264_param_t
     /* Muxing parameters */
     int b_aud;                  /* generate access unit delimiters */
     int b_repeat_headers;       /* put SPS/PPS before each keyframe */
-    int b_annexb;               /* if set, place start codes (4 bytes) before NAL units,
+    int b_annexb;               /* if set, place start codes (3 or 4 bytes) before NAL units,
                                  * otherwise place size (4 bytes) before NAL units. */
+    int b_long_startcode;       /* always use 4-byte start codes before NAL units (needed for WebRTC) */
     int i_sps_id;               /* SPS and PPS id number */
     int b_vfr_input;            /* VFR input.  If 1, use timebase and timestamps for ratecontrol purposes.
                                  * If 0, use fps only. */


### PR DESCRIPTION
(needed for WebRTC bitstream parser)